### PR TITLE
Add --tag-prefix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ chandler is in a pre-1.0 state. This means that its APIs and behavior are subjec
 
 * Your contribution here!
 * If Chandler can't find any version tags, print an error message rather than exiting silently.
+* Add `--tag-prefix` option to allow for other Git version tag formats (e.g. `myapp-v1.0.0`; see [#3](https://github.com/mattbrictson/chandler/issues/3))
 
 ## [0.1.2][] (2015-10-26)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 chandler scans your git repository for version tags (e.g. `v1.0.2`), parses out the corresponding release notes for those tags from your CHANGELOG, and uploads those notes to the GitHub releases area via the GitHub API.
 
+Chandler makes reasonable assumptions as to the name of your CHANGELOG file, your project's GitHub repository URL, and the naming convention of your Git version tags. These can all be overridden with command line options.
+
 ### Why go through the trouble?
 
 GitHub's releases feature is a nice UI for browsing the history of your project and downloading snapshots of each version. It is also structured data that can be queried via GitHub's API, making it a available for third-party integrations. For example, [Sibbell][] can automatically send the release notes out to interested parties whenever you publish a new version.
@@ -72,6 +74,7 @@ Other command-line options:
 * `--git=/path/to/project/.git` – location of the local git repository (defaults to `.git`)
 * `--github=username/repo` – GitHub repository to upload to (if unspecified, chandler will guess based on your git remotes)
 * `--changelog=History.md` – location of the CHANGELOG (defaults to `CHANGELOG.md`)
+* `--tag-prefix=myapp-` – specify Git version tags are in the format `myapp-1.0.0` instead of `1.0.0`
 
 
 ## Rakefile integration

--- a/lib/chandler/cli.rb
+++ b/lib/chandler/cli.rb
@@ -41,7 +41,7 @@ module Chandler
 
     def push
       Chandler::Commands::Push.new(
-        :tags => args.empty? ? config.git.version_tags : args,
+        :tags => args.empty? ? config.git.tagged_versions : args,
         :config => config
       )
     end

--- a/lib/chandler/cli/parser.rb
+++ b/lib/chandler/cli/parser.rb
@@ -51,6 +51,11 @@ module Chandler
             config.changelog_path = p
           end
 
+          opts.on("--tag-prefix=[PREFIX]",
+                  "Use PREFIX to identify Git version tags") do |p|
+            config.tag_prefix = p
+          end
+
           opts.on("--dry-run",
                   "Simulate, but don’t actually push to GitHub") do |d|
             config.dry_run = d

--- a/lib/chandler/configuration.rb
+++ b/lib/chandler/configuration.rb
@@ -37,7 +37,7 @@ module Chandler
     end
 
     def tag_mapper
-      return :itself if tag_prefix.nil?
+      return ->(tag) { tag } if tag_prefix.nil?
       ->(tag) { tag[/^#{Regexp.escape(tag_prefix)}(.*)/, 1] }
     end
   end

--- a/lib/chandler/configuration.rb
+++ b/lib/chandler/configuration.rb
@@ -5,8 +5,8 @@ require "chandler/logger"
 
 module Chandler
   class Configuration
-    attr_accessor :changelog_path, :git_path, :github_repository, :dry_run
-    attr_accessor :logger
+    attr_accessor :changelog_path, :git_path, :github_repository, :dry_run,
+                  :tag_prefix, :logger
 
     def initialize
       @changelog_path = "CHANGELOG.md"
@@ -20,7 +20,7 @@ module Chandler
     end
 
     def git
-      @git ||= Chandler::Git.new(:path => git_path)
+      @git ||= Chandler::Git.new(:path => git_path, :tag_mapper => tag_mapper)
     end
 
     def github
@@ -34,6 +34,11 @@ module Chandler
 
     def github_repository
       @github_repository || git.origin_remote
+    end
+
+    def tag_mapper
+      return :itself if tag_prefix.nil?
+      ->(tag) { tag[/^#{Regexp.escape(tag_prefix)}(.*)/, 1] }
     end
   end
 end

--- a/lib/chandler/git.rb
+++ b/lib/chandler/git.rb
@@ -7,26 +7,28 @@ module Chandler
     using Chandler::Refinements::VersionFormat
 
     Error = Class.new(StandardError)
-    attr_reader :path
+    attr_reader :path, :tag_mapper
 
     # Initializes the Git object with the path to the `.git` directory of the
     # desired git repository.
     #
     # Chandler::Git.new(:path => "/path/to/my/project/.git")
     #
-    def initialize(path:)
+    def initialize(path:, tag_mapper:)
       @path = path
+      @tag_mapper = tag_mapper
     end
 
     # Uses `git tag -l` to obtain the list of tags, then returns the subset of
     # those tags that appear to be version numbers.
     #
-    # version_tags # => ["v0.0.1", "v0.2.0", "v0.2.1", "v0.3.0"]
+    # tagged_versions # => ["v0.0.1", "v0.2.0", "v0.2.1", "v0.3.0"]
     #
     # rubocop:disable Style/SymbolProc
-    def version_tags
-      tags = git("tag", "-l").lines.map(&:strip).select { |v| v.version? }
-      tags.sort_by { |t| Gem::Version.new(t.version_number) }
+    def tagged_versions
+      tags = git("tag", "-l").lines.map(&:strip).map(&tag_mapper).compact
+      tagged_versions = tags.select { |v| v.version? }
+      tagged_versions.sort_by { |t| Gem::Version.new(t.version_number) }
     end
     # rubocop:enable Style/SymbolProc
 

--- a/test/chandler/cli/parser_test.rb
+++ b/test/chandler/cli/parser_test.rb
@@ -15,6 +15,7 @@ class Chandler::CLI::ParserTest < Minitest::Test
     assert_match("--debug", parser.usage)
     assert_match("--help", parser.usage)
     assert_match("--version", parser.usage)
+    assert_match("--tag-prefix", parser.usage)
   end
 
   def test_args
@@ -47,6 +48,7 @@ class Chandler::CLI::ParserTest < Minitest::Test
       --git=../test/.git
       --github=test/repo
       --changelog=../test/changes.md
+      --tag-prefix=myapp-
       --dry-run
     )
     config = parse_arguments(*args).config
@@ -56,6 +58,7 @@ class Chandler::CLI::ParserTest < Minitest::Test
     assert_equal("../test/.git", config.git_path)
     assert_equal("test/repo", config.github_repository)
     assert_equal("../test/changes.md", config.changelog_path)
+    assert_equal("myapp-", config.tag_prefix)
   end
 
   def test_prints_version_and_exits

--- a/test/chandler/cli_test.rb
+++ b/test/chandler/cli_test.rb
@@ -29,7 +29,7 @@ class Chandler::CLITest < Minitest::Test
 
   def test_push_is_invoked_for_all_git_tags_by_default
     @args << "push"
-    @config.git.stubs(:version_tags => %w(v1.0.0 v1.0.1))
+    @config.git.stubs(:tagged_versions => %w(v1.0.0 v1.0.1))
 
     Chandler::Commands::Push
       .expects(:new)

--- a/test/chandler/commands/push_test.rb
+++ b/test/chandler/commands/push_test.rb
@@ -51,10 +51,10 @@ class Chandler::Commands::PushTest < Minitest::Test
     push = Chandler::Commands::Push.new(:tags => [], :config => @config)
 
     Mocha::Configuration.allow(:stubbing_non_public_method) do
-      push.expects(:exit).with(1).raises("exited")
+      push.expects(:exit).with(1).throws(:exited)
     end
 
-    assert_equal("exited", assert_raises { push.call }.message)
+    assert_throws(:exited) { push.call }
     assert_match(/no version tags/i, stderr)
   end
 end

--- a/test/chandler/configuration_test.rb
+++ b/test/chandler/configuration_test.rb
@@ -14,11 +14,21 @@ class Chandler::ConfigurationTest < Minitest::Test
     refute(@config.dry_run?)
   end
 
-  def test_git
+  def test_default_git
     @config.git_path = "../test/.git"
     git = @config.git
     assert_instance_of(Chandler::Git, git)
     assert_equal("../test/.git", git.path)
+    assert_equal(:itself, git.tag_mapper)
+  end
+
+  def test_prefixed_git
+    @config.git_path = "../test/.git"
+    @config.tag_prefix = "myapp-"
+    mapper = @config.git.tag_mapper
+    assert_nil(mapper.call("1.0.1"))
+    assert_nil(mapper.call("whatever-2.5.2"))
+    assert_equal("3.1.9", mapper.call("myapp-3.1.9"))
   end
 
   def test_explict_github_repository

--- a/test/chandler/configuration_test.rb
+++ b/test/chandler/configuration_test.rb
@@ -19,7 +19,7 @@ class Chandler::ConfigurationTest < Minitest::Test
     git = @config.git
     assert_instance_of(Chandler::Git, git)
     assert_equal("../test/.git", git.path)
-    assert_equal(:itself, git.tag_mapper)
+    assert_equal(:itself, git.tag_mapper.call(:itself))
   end
 
   def test_prefixed_git

--- a/test/chandler/git_test.rb
+++ b/test/chandler/git_test.rb
@@ -5,12 +5,12 @@ require "tempfile"
 require "chandler/git"
 
 class Chandler::GitTest < Minitest::Test
-  def test_version_tags_for_empty_repo
+  def test_tagged_versions_for_empty_repo
     create_git_repo
-    assert_equal([], subject.version_tags)
+    assert_equal([], subject.tagged_versions)
   end
 
-  def test_version_tags
+  def test_tagged_versions
     create_git_repo do
       git("commit --allow-empty -m 1")
       git("tag -a v0.1.0 -m 0.1.0")
@@ -20,7 +20,21 @@ class Chandler::GitTest < Minitest::Test
       git("tag -a v0.11.0 -m 0.11.0")
       git("tag -a wip -m wip")
     end
-    assert_equal(%w(v0.1.0 v0.2.0 v0.11.0), subject.version_tags)
+    assert_equal(%w(v0.1.0 v0.2.0 v0.11.0), subject.tagged_versions)
+  end
+
+  def test_tagged_versions_with_prefix
+    create_git_repo do
+      git("commit --allow-empty -m 1")
+      git("tag -a myapp-0.1.0 -m 0.1.0")
+      git("commit --allow-empty -m 2")
+      git("tag -a myapp-0.2.0 -m 0.2.0")
+      git("commit --allow-empty -m 2")
+      git("tag -a myapp-0.11.0 -m 0.11.0")
+      git("tag -a wip -m wip")
+    end
+    mapper = ->(tag) { tag[/myapp-(.*)/, 1] }
+    assert_equal(%w(0.1.0 0.2.0 0.11.0), subject(mapper).tagged_versions)
   end
 
   def test_origin_remote_for_empty_repo
@@ -47,8 +61,8 @@ class Chandler::GitTest < Minitest::Test
 
   private
 
-  def subject
-    @git ||= Chandler::Git.new(:path => @git_path)
+  def subject(mapper=:itself)
+    @git ||= Chandler::Git.new(:path => @git_path, :tag_mapper => mapper)
   end
 
   def create_git_repo

--- a/test/chandler/git_test.rb
+++ b/test/chandler/git_test.rb
@@ -61,7 +61,7 @@ class Chandler::GitTest < Minitest::Test
 
   private
 
-  def subject(mapper=:itself)
+  def subject(mapper=->(tag) { tag })
     @git ||= Chandler::Git.new(:path => @git_path, :tag_mapper => mapper)
   end
 

--- a/test/support/mocha.rb
+++ b/test/support/mocha.rb
@@ -1,4 +1,4 @@
 require "mocha/mini_test"
 
-Mocha::Configuration.warn_when(:stubbing_non_existent_method)
+Mocha::Configuration.prevent(:stubbing_non_existent_method)
 Mocha::Configuration.warn_when(:stubbing_non_public_method)


### PR DESCRIPTION
Fixes #3.

@jhalterman Can you try out this branch at let me know if it works for you?

Just check out the `tag-prefix` branch, run `rake install` to install the gem, and then try running this on your project:

```
chandler push --dry-run --tag-prefix=typetools-
```