### PR TITLE
Don't strip tag-prefix when pushing release to GH

### DIFF
--- a/lib/chandler/cli.rb
+++ b/lib/chandler/cli.rb
@@ -41,7 +41,7 @@ module Chandler
 
     def push
       Chandler::Commands::Push.new(
-        :tags => args.empty? ? config.git.tagged_versions : args,
+        :tags => args.empty? ? config.git.version_tags : args,
         :config => config
       )
     end

--- a/lib/chandler/commands/push.rb
+++ b/lib/chandler/commands/push.rb
@@ -1,6 +1,7 @@
 require "chandler/logging"
 require "chandler/refinements/color"
 require "chandler/refinements/version_format"
+require "forwardable"
 
 module Chandler
   module Commands
@@ -8,6 +9,9 @@ module Chandler
     # from the CHANGELOG, and creates (or updates) the release notes for that
     # tag on GitHub.
     class Push
+      extend Forwardable
+      def_delegators :config, :github, :changelog, :tag_mapper
+
       include Logging
       using Chandler::Refinements::Color
       using Chandler::Refinements::VersionFormat
@@ -22,31 +26,23 @@ module Chandler
       def call
         exit_with_warning if tags.empty?
 
-        benchmarking_each_tag do |tag|
+        benchmarking_each_tag do |tag, version|
           github.create_or_update_release(
             :tag => tag,
             :title => tag.version_number,
-            :description => changelog.fetch(tag).strip
+            :description => changelog.fetch(version).strip
           )
         end
       end
 
       private
 
-      def github
-        config.github
-      end
-
-      def changelog
-        config.changelog
-      end
-
       def benchmarking_each_tag
         width = tags.map(&:length).max
         tags.each do |tag|
           ellipsis = "…".ljust(1 + width - tag.length)
           benchmark("Push #{tag.blue}#{ellipsis}") do
-            yield(tag)
+            yield(tag, tag_mapper.call(tag))
           end
         end
       end

--- a/lib/chandler/git.rb
+++ b/lib/chandler/git.rb
@@ -22,15 +22,15 @@ module Chandler
     # Uses `git tag -l` to obtain the list of tags, then returns the subset of
     # those tags that appear to be version numbers.
     #
-    # tagged_versions # => ["v0.0.1", "v0.2.0", "v0.2.1", "v0.3.0"]
+    # version_tags # => ["v0.0.1", "v0.2.0", "v0.2.1", "v0.3.0"]
     #
-    # rubocop:disable Style/SymbolProc
-    def tagged_versions
-      tags = git("tag", "-l").lines.map(&:strip).map(&tag_mapper).compact
-      tagged_versions = tags.select { |v| v.version? }
-      tagged_versions.sort_by { |t| Gem::Version.new(t.version_number) }
+    def version_tags
+      tags = git("tag", "-l").lines.map(&:strip).select do |tag|
+        version_part = tag_mapper.call(tag)
+        version_part && version_part.version?
+      end
+      tags.sort_by { |t| Gem::Version.new(tag_mapper.call(t).version_number) }
     end
-    # rubocop:enable Style/SymbolProc
 
     # Uses `git remote -v` to list the remotes and returns the URL of the
     # first one labeled "origin".

--- a/test/chandler/cli_test.rb
+++ b/test/chandler/cli_test.rb
@@ -29,7 +29,7 @@ class Chandler::CLITest < Minitest::Test
 
   def test_push_is_invoked_for_all_git_tags_by_default
     @args << "push"
-    @config.git.stubs(:tagged_versions => %w(v1.0.0 v1.0.1))
+    @config.git.stubs(:version_tags => %w(v1.0.0 v1.0.1))
 
     Chandler::Commands::Push
       .expects(:new)

--- a/test/chandler/commands/push_test.rb
+++ b/test/chandler/commands/push_test.rb
@@ -22,6 +22,13 @@ class Chandler::Commands::PushTest < Minitest::Test
     push.call
   end
 
+  def test_changelog_is_used_to_obtain_notes_using_tag_mapper
+    @config.stubs(:tag_mapper).returns(->(_tag) { "foo" })
+    @config.changelog.expects(:fetch).with("foo").returns("notes")
+    push = Chandler::Commands::Push.new(:tags => %w(v1), :config => @config)
+    push.call
+  end
+
   def test_github_is_used_to_create_or_update_releases
     @github
       .expects(:create_or_update_release)

--- a/test/chandler/git_test.rb
+++ b/test/chandler/git_test.rb
@@ -5,12 +5,12 @@ require "tempfile"
 require "chandler/git"
 
 class Chandler::GitTest < Minitest::Test
-  def test_tagged_versions_for_empty_repo
+  def test_version_tags_for_empty_repo
     create_git_repo
-    assert_equal([], subject.tagged_versions)
+    assert_equal([], subject.version_tags)
   end
 
-  def test_tagged_versions
+  def test_version_tags
     create_git_repo do
       git("commit --allow-empty -m 1")
       git("tag -a v0.1.0 -m 0.1.0")
@@ -20,10 +20,10 @@ class Chandler::GitTest < Minitest::Test
       git("tag -a v0.11.0 -m 0.11.0")
       git("tag -a wip -m wip")
     end
-    assert_equal(%w(v0.1.0 v0.2.0 v0.11.0), subject.tagged_versions)
+    assert_equal(%w(v0.1.0 v0.2.0 v0.11.0), subject.version_tags)
   end
 
-  def test_tagged_versions_with_prefix
+  def test_version_tags_with_prefix
     create_git_repo do
       git("commit --allow-empty -m 1")
       git("tag -a myapp-0.1.0 -m 0.1.0")
@@ -34,7 +34,10 @@ class Chandler::GitTest < Minitest::Test
       git("tag -a wip -m wip")
     end
     mapper = ->(tag) { tag[/myapp-(.*)/, 1] }
-    assert_equal(%w(0.1.0 0.2.0 0.11.0), subject(mapper).tagged_versions)
+    assert_equal(
+      %w(myapp-0.1.0 myapp-0.2.0 myapp-0.11.0),
+      subject(mapper).version_tags
+    )
   end
 
   def test_origin_remote_for_empty_repo


### PR DESCRIPTION
Fixes #6. @jhalterman can you try this branch out as well? Thanks.