### PR TITLE
Ignore missing CHANGELOG versions

### DIFF
--- a/lib/chandler/changelog.rb
+++ b/lib/chandler/changelog.rb
@@ -36,6 +36,10 @@ module Chandler
       end
     end
 
+    def basename
+      File.basename(path.to_s)
+    end
+
     private
 
     # Transforms the changelog into a hash where the keys are version numbers

--- a/lib/chandler/commands/push.rb
+++ b/lib/chandler/commands/push.rb
@@ -26,23 +26,26 @@ module Chandler
       def call
         exit_with_warning if tags.empty?
 
-        benchmarking_each_tag do |tag, version|
+        each_tag_with_notes do |tag, notes|
           github.create_or_update_release(
             :tag => tag,
             :title => tag.version_number,
-            :description => changelog.fetch(version).strip
+            :description => notes
           )
         end
       end
 
       private
 
-      def benchmarking_each_tag
+      def each_tag_with_notes
         width = tags.map(&:length).max
         tags.each do |tag|
+          notes = changelog_notes_for_tag(tag)
+          next if notes.nil?
+
           ellipsis = "…".ljust(1 + width - tag.length)
           benchmark("Push #{tag.blue}#{ellipsis}") do
-            yield(tag, tag_mapper.call(tag))
+            yield(tag, notes)
           end
         end
       end
@@ -50,6 +53,14 @@ module Chandler
       def exit_with_warning
         error("No version tags found.")
         exit(1)
+      end
+
+      def changelog_notes_for_tag(tag)
+        version = tag_mapper.call(tag)
+        changelog.fetch(version).strip
+      rescue Chandler::Changelog::NoMatchingVersion
+        info("Skip #{tag} (no #{version} entry in #{changelog.basename})".gray)
+        nil
       end
     end
   end

--- a/test/chandler/commands/push_test.rb
+++ b/test/chandler/commands/push_test.rb
@@ -42,6 +42,16 @@ class Chandler::Commands::PushTest < Minitest::Test
     push.call
   end
 
+  def test_tag_prefix_is_removed_from_title_when_pushing_to_github
+    @config.tag_prefix = "app-"
+    @github
+      .expects(:create_or_update_release)
+      .with(:tag => "app-1", :title => "1", :description => "notes")
+
+    push = Chandler::Commands::Push.new(:tags => %w(app-1), :config => @config)
+    push.call
+  end
+
   def test_progress_is_pretty_printed_to_stdout
     push = Chandler::Commands::Push.new(
       :tags => %w(v1 v2.0.2 v99.1.18),

--- a/test/chandler/commands/push_test.rb
+++ b/test/chandler/commands/push_test.rb
@@ -54,6 +54,24 @@ class Chandler::Commands::PushTest < Minitest::Test
     assert_match("Push v99.1.18… ✔", stdout)
   end
 
+  def test_skipped_tag_is_printed_to_stdout
+    @config.changelog
+           .stubs(:fetch)
+           .with("v2.0.2")
+           .raises(Chandler::Changelog::NoMatchingVersion)
+
+    push = Chandler::Commands::Push.new(
+      :tags => %w(v1 v2.0.2 v99.1.18),
+      :config => @config
+    )
+    push.call
+
+    assert_match("Push v1…       ✔", stdout)
+    refute_match("Push v2.0.2…   ✔", stdout)
+    assert_match("Skip v2.0.2 (no v2.0.2 entry in CHANGELOG.md)", stdout)
+    assert_match("Push v99.1.18… ✔", stdout)
+  end
+
   def test_exits_with_warning_if_no_tags
     push = Chandler::Commands::Push.new(:tags => [], :config => @config)
 


### PR DESCRIPTION
Fixes #5 

In case a version tag lacks a corresponding CHANGELOG entry, print a warning instead of exiting with an exception.

Can you test, @jhalterman?