### PR TITLE
Support Setext-style h1-level headings

### DIFF
--- a/lib/chandler/changelog.rb
+++ b/lib/chandler/changelog.rb
@@ -16,7 +16,8 @@ module Chandler
       /^=[[:space:]]+.*\n/,   # Rdoc style
       /^==[[:space:]]+.*\n/,
       /^===[[:space:]]+.*\n/,
-      /^\S.*\n-+\n/           # Markdown "Setext" style
+      /^\S.*\n=+\n/,          # Markdown "Setext" style
+      /^\S.*\n-+\n/
     ].freeze
 
     attr_reader :path


### PR DESCRIPTION
This fills a gap left by the recent change to support H1 headings (576f287).

We have several projects that use this style heading in the CHANGELOGs.