### PR TITLE
Add regex to allow single line versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ chandler is in a pre-1.0 state. This means that its APIs and behavior are subjec
 
 ## [Unreleased][]
 
-* Your contribution here!
+* Support for reStructuredText `definition-list` style CHANGELOG layouts.
 
 ## [0.3.1][] (2016-05-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ chandler is in a pre-1.0 state. This means that its APIs and behavior are subjec
 
 ## [Unreleased][]
 
+* Your contribution here!
 * Support for reStructuredText `definition-list` style CHANGELOG layouts.
 
 ## [0.3.1][] (2016-05-13)

--- a/lib/chandler/changelog.rb
+++ b/lib/chandler/changelog.rb
@@ -18,7 +18,7 @@ module Chandler
       /^===[[:space:]]+.*\n/,
       /^\S.*\n=+\n/,          # Markdown "Setext" style
       /^\S.*\n-+\n/,
-      /^[0-9]+[0-9A-Za-z_\.\+-]+[[:space:]]*\n/ # Lines with version string
+      /^[vr]?[0-9]+\S+[[:space:]]*\n/ # Lines with version string
     ].freeze
 
     attr_reader :path

--- a/lib/chandler/changelog.rb
+++ b/lib/chandler/changelog.rb
@@ -17,7 +17,8 @@ module Chandler
       /^==[[:space:]]+.*\n/,
       /^===[[:space:]]+.*\n/,
       /^\S.*\n=+\n/,          # Markdown "Setext" style
-      /^\S.*\n-+\n/
+      /^\S.*\n-+\n/,
+      /^[0-9]+[0-9A-Za-z_\.\+-]+[[:space:]]*\n/ # Lines with version string
     ].freeze
 
     attr_reader :path

--- a/test/chandler/changelog_test.rb
+++ b/test/chandler/changelog_test.rb
@@ -144,6 +144,17 @@ class Chandler::ChangelogTest < Minitest::Test
     assert_match("RLMArray has been split into", changelog.fetch("v0.87.0"))
   end
 
+  def test_fetch_rst_definitions_semver
+    changelog = new_changelog("rst-definition.md")
+
+    assert_match("Added ACME project", changelog.fetch("0.0.1"))
+    assert_match("Pre-release", changelog.fetch("0.0.2-rc1"))
+    assert_match("Dev pre-release", changelog.fetch("0.0.2-dev-xyz"))
+    assert_match("Release", changelog.fetch("0.0.2"))
+    assert_match("Release 0.1", changelog.fetch("0.1.0"))
+    assert_match("Update", changelog.fetch("v0.1.1"))
+  end
+
   def test_fetch_rubocop_versions
     changelog = new_changelog("rubocop.md")
 

--- a/test/fixtures/changelog/rst-definition.md
+++ b/test/fixtures/changelog/rst-definition.md
@@ -1,0 +1,18 @@
+0.0.1
+  - Added ACME project.
+
+0.0.2-rc1
+  - Pre-release.
+
+0.0.2-dev-xyz
+  - Dev pre-release.
+
+0.0.2
+  - Release.
+
+0.1.0
+  - Release 0.1
+
+v0.1.1
+  - Update.
+


### PR DESCRIPTION
Regex matching lines starting with digit, followed by
semver allowed characters only.

Enables use of rST definitions lists for main changelog format.

----

See commit msg above. This is my first ruby hack, I cant say I know much about Ruby commit etiquette. Please bear with me.

The additional regex loosens the title prefix/underline requirement a bit. It enables changelogs such as:

https://raw.githubusercontent.com/dotmpe/git-versioning/master/ChangeLog.rst
(https://github.com/dotmpe/git-versioning/blob/master/ChangeLog.rst)

Chandler works like a charm, thanks!