### PR TITLE
Drop support for Ruby < 2.3; upgrade to Bundler 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,16 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
 before_install:
   - gem update --system
-  - gem install bundler --no-document
+  - gem install bundler --conservative --no-document -v "~> 2.0"
 matrix:
   include:
-    # Run Danger only once, on 2.4.3
-    - rvm: 2.4.3
+    # Run Danger only once, on 2.6.0
+    - rvm: 2.6.0
       script: bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   - gem update --system
   - gem install bundler --conservative --no-document -v "~> 2.0"
 matrix:
+  allow_failures:
+    - rvm: ruby-head
   include:
     # Run Danger only once, on 2.6.0
     - rvm: 2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ chandler is in a pre-1.0 state. This means that its APIs and behavior are subjec
 ## [Unreleased][]
 
 * Your contribution here!
+* **Drop support for EOL Rubies.** Chandler now requires Ruby >= 2.3.
 
 ## [0.7.0][] (2016-12-23)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ chandler scans your git repository for version tags (e.g. `v1.0.2`), parses out 
 By default, chandler makes reasonable assumptions about:
 
 - the name of your `CHANGELOG` file,
-- your project's GitHub repository URL, and 
-- the naming convention of your Git version tags. 
+- your project's GitHub repository URL, and
+- the naming convention of your Git version tags.
 
 These can all be overridden with command line options.
 
@@ -24,16 +24,16 @@ These can all be overridden with command line options.
 
 [GitHub Releases][gh-releases] are a nice UI for browsing the history of your project and downloading snapshots of each version. It is also structured data that can be queried via GitHub's API, making it a available for third-party integrations. For example, [Sibbell][] can automatically send the release notes out to interested parties whenever you publish a new version.
 
-But as a considerate developer, you also want a plain text `CHANGELOG` that travels with the code, can be edited collaboratively in pull requests, and so on. 
+But as a considerate developer, you also want a plain text `CHANGELOG` that travels with the code, can be edited collaboratively in pull requests, and so on.
 
 _But that means you need two copies of the same release notes!_ 😵
 
-**chandler takes the hassle out of maintaining these two separate formats.** 
+**chandler takes the hassle out of maintaining these two separate formats.**
 Your `CHANGELOG` is the authoritative source, and GitHub Releases are updated with a simple `chandler` command.
 
 ## Requirements
 
-* Ruby 2.1 or higher
+* Ruby 2.3 or higher
 * Your project's `CHANGELOG` must be in Markdown, with version numbers in the headings (similar to the format advocated by [keepachangelog.com](http://keepachangelog.com))
 * You must be an _owner_ or _collaborator_ of the GitHub repository to update its Releases
 
@@ -74,7 +74,7 @@ To push all `CHANGELOG` entries for all tags to GitHub, just run:
 chandler push
 ```
 
-chandler will make educated guesses as to what GitHub repository to use, the location of the `CHANGELOG`, and which tags represent releases. 
+chandler will make educated guesses as to what GitHub repository to use, the location of the `CHANGELOG`, and which tags represent releases.
 
 You can preview what will happen without actually making changes, using `--dry-run`:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,13 @@ skip_tags: true
 
 environment:
   matrix:
-    - ruby_version: "21"
-    - ruby_version: "21-x64"
+    - ruby_version: "25"
+    - ruby_version: "25-x64"
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - gem update --system
-  - gem install bundler --no-document --force
+  - gem install bundler --no-document
   - bundle install --retry=3
 
 test_script:

--- a/chandler.gemspec
+++ b/chandler.gemspec
@@ -20,10 +20,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_dependency "netrc"
   spec.add_dependency "octokit", ">= 2.2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "coveralls", "~> 0.8.20"
   spec.add_development_dependency "danger", "~> 4.3"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/test/chandler/git_test.rb
+++ b/test/chandler/git_test.rb
@@ -59,7 +59,7 @@ class Chandler::GitTest < Minitest::Test
       subject.origin_remote
     end
     assert_match("Failed to execute: git", error.message)
-    assert_match("Not a git repository: 'non-existent-path'", error.message)
+    assert_match(/Not a git repository: 'non-existent-path'/i, error.message)
   end
 
   private

--- a/test/support/mocha.rb
+++ b/test/support/mocha.rb
@@ -1,5 +1,5 @@
 require "minitest"
-require "mocha/mini_test"
+require "mocha/minitest"
 
 Mocha::Configuration.prevent(:stubbing_non_existent_method)
 Mocha::Configuration.warn_when(:stubbing_non_public_method)


### PR DESCRIPTION
Also fix:

* mocha deprecation warning
* intermittent git test failure

Mute Travis failures for ruby-head since there seems to be an upstream rvm bug.