### PR TITLE
Work around rvm ruby-head build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ rvm:
 before_install:
   - gem update --system
   - gem install bundler --conservative --no-document -v "~> 2.0"
+  - gem install executable-hooks --conservative --no-document
 matrix:
-  allow_failures:
-    - rvm: ruby-head
   include:
     # Run Danger only once, on 2.6.0
     - rvm: 2.6.0


### PR DESCRIPTION
Currently rvm fails to install ruby-head completely on Travis with errors like:

    there was an error installing gem gem-wrappers

This leaves the ruby environment in an inconsistent state where binstubs fail to execute with errors like:

    /usr/bin/env: ruby_executable_hooks: No such file or directory

Manually installing the executable-hooks gem fixes these errors.