### PR TITLE
Fix travis build failure with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.6.0
   - ruby-head
 before_install:
-  - gem update --system
   - gem install bundler --conservative --no-document -v "~> 2.0"
   - gem install executable-hooks --conservative --no-document
 matrix:


### PR DESCRIPTION
The rubygems upgrade seems to lead to a prompt like this that waits for user input, eventually timing out and failing the build:

```
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-head/bin/bundle
Overwrite the executable? [yN]
```

Fix by removing the rubygems upgrade.